### PR TITLE
Parse server - Mastree changes to fetch the active socket connection to show live users count

### DIFF
--- a/cloud/main.js
+++ b/cloud/main.js
@@ -1,0 +1,43 @@
+// Cloud code - listen on the parser for the custom event to update the live viewers count
+Parse.Cloud.onLiveQueryEvent(
+  ({
+    event,
+    className,
+    queryName,
+  }) => {
+    if (event == 'subscribe' && className) {
+      if (className == 'Masterclass' && queryName.name && queryName.name == 'masterclassLive') {
+        const query = new Parse.Query(className);
+        query.equalTo('name', 'masterclassLive');
+        query
+          .find()
+          .then(results => {
+            results.forEach(live => {
+              live.increment('livecount');
+              live.save();
+            });
+          })
+          .catch(error => {
+            console.log(error);
+          });
+      }
+    } else if (event == 'ws_disconnect' && className) {
+      if (className == 'Masterclass' && queryName.name && queryName.name == 'masterclassLive') {
+        const query = new Parse.Query(className);
+        query.equalTo('name', 'masterclassLive');
+        query
+          .find()
+          .then(results => {
+            results.forEach(live => {
+              live.decrement('livecount');
+              live.save();
+            });
+          })
+          .catch(error => {
+            console.log(error);
+          });
+      }
+    }
+    return;
+  }
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  parse:
+    build: .
+    ports:
+      - '1337:1337'
+    environment:
+      - PARSE_SERVER_APPLICATION_ID=${APP_ID}
+      - PARSE_SERVER_MASTER_KEY=${MASTER_KEY}
+      - PARSE_SERVER_DATABASE_URI=${DB_URL}
+      - PARSE_SERVER_START_LIVE_QUERY_SERVER=1
+      - PARSE_SERVER_LIVE_QUERY={"classNames":["TempTable","MyClass","Session","AudioVideoState","Test_AudioVideoState","Masterclass"],"redisURL":${REDIS_URL}}
+      - PARSE_SERVER_LIVE_QUERY_SERVER_OPTIONS={"redisURL":${REDIS_URL}}
+      - PARSE_SERVER_CLOUD=/parse-server/cloud/main.js
+      - VERBOSE=false
+    volumes:
+      - 'parse_data:/parse_data'
+      - './cloud:/parse-server/cloud'
+    restart: always
+volumes:
+  parse_data:
+    driver: local

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -399,9 +399,13 @@ class ParseLiveQueryServer {
       const client = this.clients.get(clientId);
       this.clients.delete(clientId);
 
+      let className = undefined
+      let queryName = undefined
       // Delete client from subscriptions
       for (const [requestId, subscriptionInfo] of _.entries(client.subscriptionInfos)) {
         const subscription = subscriptionInfo.subscription;
+        className = subscription.className
+        queryName = subscription.query
         subscription.deleteClientSubscription(clientId, requestId);
 
         // If there is no client which is subscribing this subscription, remove it from subscriptions
@@ -420,6 +424,8 @@ class ParseLiveQueryServer {
       runLiveQueryEventHandlers({
         event: 'ws_disconnect',
         clients: this.clients.size,
+        className: className,
+        queryName: queryName,
         subscriptions: this.subscriptions.size,
         useMasterKey: client.hasMasterKey,
         installationId: client.installationId,
@@ -667,6 +673,8 @@ class ParseLiveQueryServer {
     }
     const client = this.clients.get(parseWebsocket.clientId);
     const className = request.query.className;
+    const queryName = request.query.where;
+    
     try {
       await maybeRunSubscribeTrigger('beforeSubscribe', className, request);
 
@@ -712,6 +720,8 @@ class ParseLiveQueryServer {
         client,
         event: 'subscribe',
         clients: this.clients.size,
+        className: className,
+        queryName: queryName,
         subscriptions: this.subscriptions.size,
         sessionToken: request.sessionToken,
         useMasterKey: client.hasMasterKey,


### PR DESCRIPTION
In order to get the current socket connection based on live query subscription, changes are made to send the class name and the query that the subscription channel has been created. 

Cloud code is created to actively listen to the events and update the masterclass subscription counts in the row field (which gets updated in the app as real-time viewers).